### PR TITLE
Modify RANSAC score

### DIFF
--- a/src/feature/RansacFeatureSetMatcher.cpp
+++ b/src/feature/RansacFeatureSetMatcher.cpp
@@ -26,13 +26,14 @@
 #include <sys/time.h>
 
 
-RansacFeatureSetMatcher::RansacFeatureSetMatcher(double acceptanceThreshold, double successProbability, double inlierProbability, double distanceThreshold, double rigidityThreshold, bool adaptive):
+RansacFeatureSetMatcher::RansacFeatureSetMatcher(double acceptanceThreshold, double successProbability, double inlierProbability, double distanceThreshold, double rigidityThreshold, bool adaptive, bool inliersScore):
     AbstractFeatureSetMatcher(acceptanceThreshold),
     m_successProbability(successProbability),
     m_inlierProbability(inlierProbability),
     m_distanceThreshold(distanceThreshold),
     m_rigidityThreshold(rigidityThreshold),
-    m_adaptive(adaptive)
+    m_adaptive(adaptive),
+    m_scoreInliersOnly(inliersScore)
 {
 
 }
@@ -124,7 +125,9 @@ double RansacFeatureSetMatcher::matchSets(const std::vector<InterestPoint *> &re
     }
     compute2DPose(pointCorrespondences, transformation);
     double score = verifyHypothesis(reference, data, transformation, correspondences);
-    // Modify the score to be the sum of the errors of the inliers only
-    score -= (data.size()-correspondences.size())*m_acceptanceThreshold;
+    if (m_scoreInliersOnly){
+      // Modify the score to be the sum of the errors of the inliers only
+      score -= (data.size()-correspondences.size())*m_acceptanceThreshold;
+    }
     return score;   
 }

--- a/src/feature/RansacFeatureSetMatcher.cpp
+++ b/src/feature/RansacFeatureSetMatcher.cpp
@@ -123,5 +123,8 @@ double RansacFeatureSetMatcher::matchSets(const std::vector<InterestPoint *> &re
 	pointCorrespondences[i] = std::make_pair(correspondences[i].first->getPosition(), correspondences[i].second->getPosition());
     }
     compute2DPose(pointCorrespondences, transformation);
-    return verifyHypothesis(reference, data, transformation, correspondences);
+    double score = verifyHypothesis(reference, data, transformation, correspondences);
+    // Modify the score to be the sum of the errors of the inliers only
+    score -= (data.size()-correspondences.size())*m_acceptanceThreshold;
+    return score;   
 }

--- a/src/feature/RansacFeatureSetMatcher.h
+++ b/src/feature/RansacFeatureSetMatcher.h
@@ -47,7 +47,7 @@ class RansacFeatureSetMatcher: public AbstractFeatureSetMatcher {
 	 * @param rigidityThreshold The maximum value (in meters) of difference between the relative distance of two interest points. This implements a rigidity check in the RANSAC hypothesis generation.
 	 * @param adaptive The flag to set the adaptive strategy to compute the number of RANSAC iterations (EXPERIMENTAL!!!).
 	 */
-	RansacFeatureSetMatcher(double acceptanceThreshold, double successProbability, double inlierProbability, double distanceThreshold, double rigidityThreshold, bool adaptive = false);
+       RansacFeatureSetMatcher(double acceptanceThreshold, double successProbability, double inlierProbability, double distanceThreshold, double rigidityThreshold, bool adaptive = false, bool inliersScore = false);
 	
 	/** Default destructor. */
 	virtual ~RansacFeatureSetMatcher() { }
@@ -95,6 +95,7 @@ class RansacFeatureSetMatcher: public AbstractFeatureSetMatcher {
 	double m_distanceThreshold; /**< The maximum distance (dimensionless) for two descriptors to be considered as a valid match. This threshold depends on the actual distance employed. */
 	double m_rigidityThreshold; /**< The maximum value (in meters) of difference between the relative distance of two interest points. This implements a rigidity check in the RANSAC hypothesis generation. */
 	bool m_adaptive; /**< The flag to set the adaptive strategy to compute the number of RANSAC iterations (EXPERIMENTAL!!!). */
+	bool m_scoreInliersOnly; /** This flag causes the returned score to involve only the found inliers. */
 };
 
 #endif


### PR DESCRIPTION
modify the returned ransac score to be the sum of the errors of the inliers only.
This makes it easier to define a threshold on this score.

@efernandez 
