### PR TITLE
Ransac Fixes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -135,7 +135,7 @@ INCLUDE_DIRECTORIES(${FLIRT_SOURCE_DIR}/src)
 SET(LOCAL_OPTIMIZATION_FLAGS "-O3 -march=nocona -msse4.1 -funroll-loops -ftree-vectorize -DTBB -mfpmath=both")
 # SET(LOCAL_OPTIMIZATION_FLAGS "-O3 -march=native -msse4.2 -msse4.1 -funroll-loops -ftree-vectorize -DTBB -mfpmath=both")
 SET(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} ${LOCAL_OPTIMIZATION_FLAGS}")
-SET(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -std=gnu++0x ${LOCAL_OPTIMIZATION_FLAGS}")
+SET(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} ${LOCAL_OPTIMIZATION_FLAGS}")
 
 #Debug (it can clash with optimization)
 SET(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -O0 -g3 -ggdb3 -fno-inline -Wall")

--- a/src/feature/RansacFeatureSetMatcher.cpp
+++ b/src/feature/RansacFeatureSetMatcher.cpp
@@ -127,7 +127,7 @@ double RansacFeatureSetMatcher::matchSets(const std::vector<InterestPoint *> &re
     }
     
     // Check if there are enough absolute matches 
-    if(possibleCorrespondences.size() < 2){  
+    if (possibleCorrespondences.size() < 2){
 //      std::cout << "Not enough possible correspondences" << std::endl;
         return 1e17;
     }
@@ -146,7 +146,7 @@ double RansacFeatureSetMatcher::matchSets(const std::vector<InterestPoint *> &re
     }
     
     // Check if there are enough matches compared to the inlier probability 
-    if(double(possibleCorrespondences.size()) * m_inlierProbability < 2)
+    if (double(possibleCorrespondences.size()) * m_inlierProbability < 2)
     {
         std::cout << "WARNING: not enough possible correspondences for the inlier probability" << std::endl;
     }
@@ -155,7 +155,7 @@ double RansacFeatureSetMatcher::matchSets(const std::vector<InterestPoint *> &re
     boost::uniform_smallint<int> generator(0, possibleCorrespondences.size() - 1);
     
 
-    double inlierProbability = m_adaptive ? 2.0 / data.size() : m_inlierProbability;
+    double inlierProbability = m_adaptive ? 2.0 / possibleCorrespondences.size() : m_inlierProbability;
     unsigned int iterations = ceil(log(1. - m_successProbability)/log(1. - inlierProbability * inlierProbability));
 
     // Main loop
@@ -190,8 +190,10 @@ double RansacFeatureSetMatcher::matchSets(const std::vector<InterestPoint *> &re
 	    
 	    // Adapt the number of iterations
 	    if (m_adaptive){
-		inlierProbability = double(correspondences.size())/double(data.size());
-                iterations = inlierProbability > 0.9 ? 0 : ceil(log(1. - m_successProbability)/log(1. - inlierProbability * inlierProbability));
+               inlierProbability = static_cast<double>(correspondences.size())/data.size();
+               const double inlierProbabilitySquared = inlierProbability * inlierProbability;
+               iterations = inlierProbabilitySquared > m_successProbability ? 1 :
+                            ceil(log(1. - m_successProbability)/log(1. - inlierProbabilitySquared));
 	    }
 	}
     }

--- a/src/feature/RansacFeatureSetMatcher.cpp
+++ b/src/feature/RansacFeatureSetMatcher.cpp
@@ -36,7 +36,7 @@ bool indexedDistanceCompare(const IndexedDistance& first, const IndexedDistance&
 
 RansacFeatureSetMatcher::RansacFeatureSetMatcher(double acceptanceThreshold, double successProbability, double inlierProbability, double distanceThreshold, double rigidityThreshold, bool adaptive, bool inliersScore):
     AbstractFeatureSetMatcher(acceptanceThreshold),
-    m_successProbability(successProbability),
+    m_successProbability(std::min(std::max(successProbability, 0.0), 0.999)),
     m_inlierProbability(inlierProbability),
     m_distanceThreshold(distanceThreshold),
     m_rigidityThreshold(rigidityThreshold),


### PR DESCRIPTION
- Do not return prematurley if the probability of finding enough inliers is too low
- Do not use log(1 - inlierProbability) if inlierProbability is close to 1
- Do not use C++11 in release mode. Causes a crash related to flann::any
- @efernandez  @servos 
